### PR TITLE
Bug 1491022 - upgrade lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "debug": "^2.1.3",
     "dockerode": "2.1.4",
     "dockerode-promise": "0.1.0",
-    "lodash": "^3.9.3",
+    "lodash": "^4.17.11",
     "promise": "6.1.0",
     "slugid": "1.0.3",
     "through2": "^2.0.0",


### PR DESCRIPTION
The 3 -> 4 transition did not change the behavior of `_.defaults`, which
is all this library uses.