### PR TITLE
Run without TTY in Taskcluster

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -60,4 +60,4 @@ tasks:
                 git checkout --no-progress "${head_rev}"
                 chmod a+x ../bin/docker-compose
                 ../bin/docker-compose build --build-arg "NODE_VERSION=${env.node_image_tag}"
-                ../bin/docker-compose run --rm test
+                ../bin/docker-compose run --rm --no-TTY test


### PR DESCRIPTION
When running with an auto-allocated TTY, the test output is often omitted from the live log.